### PR TITLE
You can ass "s" to employer

### DIFF
--- a/src/services/EmployerService.js
+++ b/src/services/EmployerService.js
@@ -2,6 +2,6 @@ import axios from "axios";
 
 export default class EmployerService {
   getEmployers() {
-    return axios.get("http://localhost:8080/api/employer/getall");
+    return axios.get("http://localhost:8080/api/employers/getall");
   }
 }


### PR DESCRIPTION
Api names should plural. You can change "employer" as "employers" in both frontend , backend code.